### PR TITLE
fix: 履歴100件超で advance() 後に history_position がズレるバグを修正

### DIFF
--- a/src-tauri/src/playlist.rs
+++ b/src-tauri/src/playlist.rs
@@ -99,6 +99,10 @@ impl Playlist {
         // 履歴に追加（最大100件）
         if self.history.len() >= 100 {
             self.history.remove(0);
+            // 先頭削除により全要素が1つ前にシフトするため history_position を補正
+            if self.history_position > 0 {
+                self.history_position -= 1;
+            }
         }
         self.history.push(self.current_index);
         self.history_position = self.history.len() - 1;
@@ -270,5 +274,32 @@ mod tests {
         // 画像を削除
         playlist.update_images(vec![], vec!["img2.jpg".to_string()]);
         assert_eq!(playlist.total_count(), 2);
+    }
+
+    #[test]
+    fn test_history_position_after_overflow() {
+        // 100件超で履歴が溢れたとき、go_back() → advance() が should_count=false を返すことを確認
+        // 200枚の画像でプレイリストを作成
+        let images: Vec<String> = (0..200).map(|i| format!("img{}.jpg", i)).collect();
+        let mut playlist = Playlist::new(images);
+
+        // 101回 advance() して履歴を溢れさせる
+        for _ in 0..101 {
+            playlist.advance();
+        }
+
+        // この時点で履歴は100件満杯
+        assert!(playlist.can_go_back());
+
+        // 1つ戻る（履歴内に入る）
+        playlist.go_back();
+
+        // 再度 advance() → 履歴内の移動なので should_count = false であるべき
+        let (img, should_count) = playlist.advance();
+        assert!(img.is_some());
+        assert!(
+            !should_count,
+            "履歴内を進む場合は should_count=false であるべき（history_position ズレバグの検証）"
+        );
     }
 }


### PR DESCRIPTION
## 関連 Issue
closes #5

## 変更内容

### バグの内容
`Playlist::advance()` 内で履歴が100件を超えたとき、`history.remove(0)` で先頭要素を削除するが、`history_position` の補正が行われていなかった。

削除後に全要素が1つ前にシフトするため、`history_position` が指す要素がズレ、その後 `go_back()` → `advance()` した際に `is_in_history` 判定が狂い、`should_count=true`（二重カウント）になる可能性があった。

### 修正内容
`history.remove(0)` の直後に `history_position > 0` なら1減算する補正を追加。

### テスト追加
`test_history_position_after_overflow` — 101回 advance して履歴を溢れさせた後、`go_back()` → `advance()` で `should_count=false` を確認するテストを追加。