### PR TITLE
fix: 論理削除廃止・削除済みファイルをDBから物理削除に変更

### DIFF
--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -108,7 +108,11 @@ impl Database {
             .unwrap_or(0)
             > 0;
         if has_is_valid {
-            // is_valid = 0 の行（論理削除済み）を物理削除
+            // is_valid = 0 の行（論理削除済み）とその image_stats を物理削除
+            self.conn.execute(
+                "DELETE FROM image_stats WHERE path IN (SELECT path FROM file_metadata WHERE is_valid = 0)",
+                [],
+            )?;
             self.conn
                 .execute("DELETE FROM file_metadata WHERE is_valid = 0", [])?;
             // is_valid インデックスを削除


### PR DESCRIPTION
## 関連 Issue
closes #11

## 変更内容

### database.rs
- `file_metadata` テーブルから `is_valid` カラムを廃止
- `mark_deleted()` を `UPDATE SET is_valid = 0` → `DELETE FROM file_metadata` + `DELETE FROM image_stats` に変更（同一トランザクション内）
- `get_all_file_metadata()` の `WHERE is_valid = 1` 句を削除
- `get_total_image_count()` の `WHERE is_valid = 1` 句を削除
- `upsert_file_metadata()` の `INSERT OR REPLACE` から `is_valid = 1` 指定を削除
- `idx_is_valid` インデックスを廃止

### スキーママイグレーション
既存DBへの対応として `init_schema()` 内でマイグレーション処理を追加:
- `is_valid` カラムが存在する旧スキーマを検出
- `is_valid = 0` の論理削除行を物理削除
- `idx_is_valid` インデックスを削除
- `ALTER TABLE ... DROP COLUMN is_valid` でカラムを廃止