### PR TITLE
chore: uninlined_format_args を一掃し clippy -D warnings を緑にする

### DIFF
--- a/src-tauri/src/commands/file_operations.rs
+++ b/src-tauri/src/commands/file_operations.rs
@@ -77,7 +77,7 @@ pub async fn open_in_explorer(image_path: String) -> Result<(), String> {
                 Command::new("xdg-open")
                     .arg(directory)
                     .spawn()
-                    .map_err(|e| format!("Failed to open file manager: {}", e))?;
+                    .map_err(|e| format!("Failed to open file manager: {e}"))?;
             }
         }
     }
@@ -126,7 +126,7 @@ pub async fn pick_image(image_path: String, state: State<'_, AppState>) -> Resul
     // ディレクトリが存在しない場合は作成
     if !share_directory.exists() {
         fs::create_dir_all(&share_directory)
-            .map_err(|e| format!("Failed to create share directory: {}", e))?;
+            .map_err(|e| format!("Failed to create share directory: {e}"))?;
     }
 
     // ファイル名を取得
@@ -142,13 +142,13 @@ pub async fn pick_image(image_path: String, state: State<'_, AppState>) -> Resul
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
-        share_directory.join(format!("{}_{}.{}", stem, timestamp, ext))
+        share_directory.join(format!("{stem}_{timestamp}.{ext}"))
     } else {
         dest_path
     };
 
     // ファイルをコピー
-    fs::copy(source_path, &final_dest_path).map_err(|e| format!("Failed to copy file: {}", e))?;
+    fs::copy(source_path, &final_dest_path).map_err(|e| format!("Failed to copy file: {e}"))?;
 
     Ok(final_dest_path.to_string_lossy().to_string())
 }
@@ -158,7 +158,7 @@ pub async fn pick_image(image_path: String, state: State<'_, AppState>) -> Resul
 pub async fn get_ignore_patterns(state: State<'_, AppState>) -> Result<Vec<String>, String> {
     let db = state.db.lock().unwrap_or_else(|e| e.into_inner());
     db.get_ignore_rules()
-        .map_err(|e| format!("Failed to get ignore rules: {}", e))
+        .map_err(|e| format!("Failed to get ignore rules: {e}"))
 }
 
 /// 除外ルールを削除
@@ -169,7 +169,7 @@ pub async fn remove_ignore_pattern(
 ) -> Result<(), String> {
     let db = state.db.lock().unwrap_or_else(|e| e.into_inner());
     db.remove_ignore_rule(&pattern)
-        .map_err(|e| format!("Failed to remove ignore rule: {}", e))
+        .map_err(|e| format!("Failed to remove ignore rule: {e}"))
 }
 
 /// 除外ルールを手動追加
@@ -177,7 +177,7 @@ pub async fn remove_ignore_pattern(
 pub async fn add_ignore_pattern(pattern: String, state: State<'_, AppState>) -> Result<(), String> {
     let db = state.db.lock().unwrap_or_else(|e| e.into_inner());
     db.add_ignore_rule(&pattern)
-        .map_err(|e| format!("Failed to add ignore rule: {}", e))
+        .map_err(|e| format!("Failed to add ignore rule: {e}"))
 }
 
 /// 除外機能：画像をDBのignore_rulesに追加
@@ -202,7 +202,7 @@ pub async fn exclude_image(
                         // "YYYY:MM:DD HH:MM:SS" から "YYYY-MM-DD" を抽出
                         let date_part = date_time.split(' ').next().unwrap_or("");
                         let date = date_part.replace(':', "-");
-                        format!("*{}*", date)
+                        format!("*{date}*")
                     } else {
                         return Err("No EXIF date found".to_string());
                     }
@@ -228,7 +228,7 @@ pub async fn exclude_image(
     // DB に除外ルールを追加
     let db = state.db.lock().unwrap_or_else(|e| e.into_inner());
     db.add_ignore_rule(&pattern)
-        .map_err(|e| format!("Failed to add ignore rule: {}", e))?;
+        .map_err(|e| format!("Failed to add ignore rule: {e}"))?;
     drop(db);
 
     // プレイリストから該当画像を削除（ファイル除外の場合のみ即座に削除）
@@ -238,12 +238,11 @@ pub async fn exclude_image(
             playlist.update_images(vec![], vec![image_path.clone()]);
         }
         drop(playlist_lock);
-        Ok(format!("除外パターン追加: {}", pattern))
+        Ok(format!("除外パターン追加: {pattern}"))
     } else {
         // 日付・ディレクトリ除外は再スキャンが必要
         Ok(format!(
-            "除外パターン追加: {} (変更を反映するには再スキャンしてください)",
-            pattern
+            "除外パターン追加: {pattern} (変更を反映するには再スキャンしてください)"
         ))
     }
 }
@@ -256,14 +255,14 @@ pub async fn get_recent_images(state: State<'_, AppState>) -> Result<Vec<RecentI
     // 除外パターンを取得してフィルタを構築
     let patterns = db
         .get_ignore_rules()
-        .map_err(|e| format!("Failed to get ignore rules: {}", e))?;
+        .map_err(|e| format!("Failed to get ignore rules: {e}"))?;
     let ignore_filter = IgnoreFilter::from_patterns(&patterns);
 
     // 最近表示した画像を多めに取得（除外フィルタ後に最大100件を返す。
     // 除外率が高い場合は100件未満になりうる）
     let all_recent = db
         .get_recent_images(500)
-        .map_err(|e| format!("Failed to get recent images: {}", e))?;
+        .map_err(|e| format!("Failed to get recent images: {e}"))?;
     drop(db);
 
     // 除外パターンにマッチしないものだけ返す（最大100件）
@@ -316,10 +315,10 @@ pub async fn get_picked_images(state: State<'_, AppState>) -> Result<Vec<String>
 
     let mut images: Vec<String> = Vec::new();
     let entries =
-        fs::read_dir(&picked_dir).map_err(|e| format!("Failed to read directory: {}", e))?;
+        fs::read_dir(&picked_dir).map_err(|e| format!("Failed to read directory: {e}"))?;
 
     for entry in entries {
-        let entry = entry.map_err(|e| format!("Failed to read entry: {}", e))?;
+        let entry = entry.map_err(|e| format!("Failed to read entry: {e}"))?;
         let path = entry.path();
         if path.is_file() {
             if let Some(ext) = path.extension() {
@@ -352,16 +351,16 @@ pub async fn delete_picked_image(
     // 安全チェック: sss-picked フォルダ内のファイルのみ削除可能
     let canonical_path = path
         .canonicalize()
-        .map_err(|e| format!("Failed to resolve path: {}", e))?;
+        .map_err(|e| format!("Failed to resolve path: {e}"))?;
     let canonical_dir = picked_dir
         .canonicalize()
-        .map_err(|e| format!("Failed to resolve picked directory: {}", e))?;
+        .map_err(|e| format!("Failed to resolve picked directory: {e}"))?;
 
     if !canonical_path.starts_with(&canonical_dir) {
         return Err("Cannot delete files outside the picked directory".to_string());
     }
 
-    fs::remove_file(path).map_err(|e| format!("Failed to delete file: {}", e))?;
+    fs::remove_file(path).map_err(|e| format!("Failed to delete file: {e}"))?;
     Ok(())
 }
 
@@ -370,5 +369,5 @@ pub async fn delete_picked_image(
 pub async fn reset_all_display_counts(state: State<'_, AppState>) -> Result<(), String> {
     let db = state.db.lock().unwrap_or_else(|e| e.into_inner());
     db.reset_all_display_counts()
-        .map_err(|e| format!("Failed to reset display counts: {}", e))
+        .map_err(|e| format!("Failed to reset display counts: {e}"))
 }

--- a/src-tauri/src/commands/image.rs
+++ b/src-tauri/src/commands/image.rs
@@ -138,9 +138,9 @@ fn get_image_info_internal(
         // キャッシュファイル名を生成（元のファイル名のハッシュを使用）
         let hash = format!(
             "{:x}",
-            md5::compute(format!("{}:{}", image_path, apply_rotation))
+            md5::compute(format!("{image_path}:{apply_rotation}"))
         );
-        let cache_file = state.cache_dir.join(format!("{}.jpg", hash));
+        let cache_file = state.cache_dir.join(format!("{hash}.jpg"));
 
         // キャッシュが存在する場合は使用
         if cache_file.exists() {
@@ -154,11 +154,11 @@ fn get_image_info_internal(
                 move || match optimize_image_for_4k(&path_clone, apply_rotation) {
                     Ok(optimized_data) => {
                         if let Err(e) = fs::write(&cache_file_clone, optimized_data) {
-                            eprintln!("Failed to write optimized image: {}", e);
+                            eprintln!("Failed to write optimized image: {e}");
                         }
                     }
                     Err(e) => {
-                        eprintln!("Failed to optimize image: {}", e);
+                        eprintln!("Failed to optimize image: {e}");
                     }
                 },
             );
@@ -222,20 +222,20 @@ fn prefetch_and_cache_multiple(image_paths: Vec<String>, cache_dir: PathBuf, app
             if width > MAX_WIDTH_4K || height > MAX_HEIGHT_4K || apply_rotation {
                 let hash = format!(
                     "{:x}",
-                    md5::compute(format!("{}:{}", image_path, apply_rotation))
+                    md5::compute(format!("{image_path}:{apply_rotation}"))
                 );
-                let cache_file = cache_dir.join(format!("{}.jpg", hash));
+                let cache_file = cache_dir.join(format!("{hash}.jpg"));
 
                 // キャッシュが既に存在する場合はスキップ
                 if !cache_file.exists() {
                     match optimize_image_for_4k(path, apply_rotation) {
                         Ok(optimized_data) => {
                             if let Err(e) = fs::write(&cache_file, optimized_data) {
-                                eprintln!("Failed to write prefetched cache: {}", e);
+                                eprintln!("Failed to write prefetched cache: {e}");
                             }
                         }
                         Err(e) => {
-                            eprintln!("Failed to optimize for prefetch: {}", e);
+                            eprintln!("Failed to optimize for prefetch: {e}");
                         }
                     }
                 }

--- a/src-tauri/src/commands/scan.rs
+++ b/src-tauri/src/commands/scan.rs
@@ -34,18 +34,18 @@ fn migrate_sssignore_to_db(db: &crate::database::Database) {
                     continue;
                 }
                 if let Err(e) = db.add_ignore_rule(line) {
-                    eprintln!("Failed to import ignore rule '{}': {}", line, e);
+                    eprintln!("Failed to import ignore rule '{line}': {e}");
                 }
             }
 
             // .sssignore を .sssignore.bak にリネーム
             let bak_path = home_dir.join(".sssignore.bak");
             if let Err(e) = std::fs::rename(&sssignore_path, &bak_path) {
-                eprintln!("Failed to rename .sssignore to .sssignore.bak: {}", e);
+                eprintln!("Failed to rename .sssignore to .sssignore.bak: {e}");
             }
         }
         Err(e) => {
-            eprintln!("Failed to read .sssignore for migration: {}", e);
+            eprintln!("Failed to read .sssignore for migration: {e}");
         }
     }
 }
@@ -60,7 +60,7 @@ pub async fn scan_directory(
     let directory = PathBuf::from(&directory_path);
 
     if !directory.exists() {
-        return Err(format!("Directory does not exist: {}", directory_path));
+        return Err(format!("Directory does not exist: {directory_path}"));
     }
 
     // マイグレーション処理：~/.sssignore が存在する場合は DB にインポート
@@ -106,13 +106,13 @@ pub async fn scan_directory(
     // 新規ファイルを追加
     for file in &scan_result.files {
         db.upsert_file_metadata(&file.path, file.modified_time, file.file_size)
-            .map_err(|e| format!("Database error: {}", e))?;
+            .map_err(|e| format!("Database error: {e}"))?;
     }
 
     // 削除されたファイルをマーク
     if !scan_result.deleted_files.is_empty() {
         db.mark_deleted(&scan_result.deleted_files)
-            .map_err(|e| format!("Database error: {}", e))?;
+            .map_err(|e| format!("Database error: {e}"))?;
     }
 
     // スキャン履歴を記録
@@ -123,11 +123,11 @@ pub async fn scan_directory(
         scan_result.deleted_count as i32,
         scan_result.duration_ms as i64,
     )
-    .map_err(|e| format!("Database error: {}", e))?;
+    .map_err(|e| format!("Database error: {e}"))?;
 
     // スキャン履歴の上限管理（100件超を削除）
     db.trim_scan_history(100)
-        .map_err(|e| format!("Database error: {}", e))?;
+        .map_err(|e| format!("Database error: {e}"))?;
 
     drop(db);
 

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -6,7 +6,7 @@ use tauri::State;
 pub fn save_setting(state: State<AppState>, key: String, value: String) -> Result<(), String> {
     let db = state.db.lock().map_err(|e| e.to_string())?;
     db.save_setting(&key, &value)
-        .map_err(|e| format!("Failed to save setting: {}", e))
+        .map_err(|e| format!("Failed to save setting: {e}"))
 }
 
 /// 設定を取得
@@ -14,7 +14,7 @@ pub fn save_setting(state: State<AppState>, key: String, value: String) -> Resul
 pub fn get_setting(state: State<AppState>, key: String) -> Result<Option<String>, String> {
     let db = state.db.lock().map_err(|e| e.to_string())?;
     db.get_setting(&key)
-        .map_err(|e| format!("Failed to get setting: {}", e))
+        .map_err(|e| format!("Failed to get setting: {e}"))
 }
 
 /// 最後に選択したディレクトリパスを取得
@@ -23,6 +23,6 @@ pub async fn get_last_directory_path(state: State<'_, AppState>) -> Result<Optio
     let db = state.db.lock().unwrap_or_else(|e| e.into_inner());
     let path = db
         .get_setting("last_directory_path")
-        .map_err(|e| format!("Database error: {}", e))?;
+        .map_err(|e| format!("Database error: {e}"))?;
     Ok(path)
 }

--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -8,11 +8,11 @@ pub async fn get_stats(state: State<'_, AppState>) -> Result<Stats, String> {
 
     let total_images = db
         .get_total_image_count()
-        .map_err(|e| format!("Database error: {}", e))?;
+        .map_err(|e| format!("Database error: {e}"))?;
 
     let displayed_images = db
         .get_displayed_image_count()
-        .map_err(|e| format!("Database error: {}", e))?;
+        .map_err(|e| format!("Database error: {e}"))?;
 
     Ok(Stats {
         total_images,
@@ -43,5 +43,5 @@ pub async fn get_playlist_info(
 pub async fn get_display_stats(state: State<'_, AppState>) -> Result<Vec<(String, i32)>, String> {
     let db = state.db.lock().unwrap_or_else(|e| e.into_inner());
     db.get_all_display_counts()
-        .map_err(|e| format!("Failed to get display stats: {}", e))
+        .map_err(|e| format!("Failed to get display stats: {e}"))
 }

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -13,20 +13,20 @@ pub async fn reset_all_data(app: AppHandle) -> Result<(), String> {
     let app_data_dir = app
         .path()
         .app_data_dir()
-        .map_err(|e| format!("Failed to get app data directory: {}", e))?;
+        .map_err(|e| format!("Failed to get app data directory: {e}"))?;
 
     let db_path = app_data_dir.join("sss.db");
     let cache_dir = app_data_dir.join("cache");
 
     // データベースファイルを削除
     if db_path.exists() {
-        std::fs::remove_file(&db_path).map_err(|e| format!("Failed to delete database: {}", e))?;
+        std::fs::remove_file(&db_path).map_err(|e| format!("Failed to delete database: {e}"))?;
     }
 
     // キャッシュディレクトリを削除
     if cache_dir.exists() {
         std::fs::remove_dir_all(&cache_dir)
-            .map_err(|e| format!("Failed to delete cache directory: {}", e))?;
+            .map_err(|e| format!("Failed to delete cache directory: {e}"))?;
     }
 
     Ok(())

--- a/src-tauri/src/ignore.rs
+++ b/src-tauri/src/ignore.rs
@@ -26,7 +26,7 @@ impl IgnoreFilter {
                     has_patterns = true;
                 }
                 Err(e) => {
-                    eprintln!("Invalid pattern '{}': {}", line, e);
+                    eprintln!("Invalid pattern '{line}': {e}");
                 }
             }
         }
@@ -40,7 +40,7 @@ impl IgnoreFilter {
                 globset: Some(globset),
             },
             Err(e) => {
-                eprintln!("Failed to build globset: {}", e);
+                eprintln!("Failed to build globset: {e}");
                 IgnoreFilter { globset: None }
             }
         }

--- a/src-tauri/src/image_processor.rs
+++ b/src-tauri/src/image_processor.rs
@@ -37,7 +37,7 @@ pub struct ImageInfo {
 /// 画像を最適化（EXIF回転適用 + 4Kリサイズ）
 pub fn optimize_image_for_4k(image_path: &Path, apply_rotation: bool) -> Result<Vec<u8>, String> {
     // 画像を読み込む
-    let img = image::open(image_path).map_err(|e| format!("Failed to open image: {}", e))?;
+    let img = image::open(image_path).map_err(|e| format!("Failed to open image: {e}"))?;
 
     // EXIF Orientationに基づいて回転・反転を適用（リサイズ前）
     let img = if apply_rotation {
@@ -59,7 +59,7 @@ pub fn optimize_image_for_4k(image_path: &Path, apply_rotation: bool) -> Result<
     let mut buffer = Vec::new();
     resized_img
         .write_to(&mut std::io::Cursor::new(&mut buffer), ImageFormat::Jpeg)
-        .map_err(|e| format!("Failed to encode image: {}", e))?;
+        .map_err(|e| format!("Failed to encode image: {e}"))?;
 
     Ok(buffer)
 }
@@ -91,14 +91,14 @@ fn apply_exif_orientation(image_path: &Path, img: image::DynamicImage) -> image:
 
 /// 画像の基本情報を取得
 pub fn get_image_dimensions(image_path: &Path) -> Result<(u32, u32), String> {
-    let img = image::open(image_path).map_err(|e| format!("Failed to open image: {}", e))?;
+    let img = image::open(image_path).map_err(|e| format!("Failed to open image: {e}"))?;
 
     Ok(img.dimensions())
 }
 
 /// EXIF情報を取得
 pub fn get_exif_info(image_path: &Path) -> Result<ExifInfo, String> {
-    let file = File::open(image_path).map_err(|e| format!("Failed to open file: {}", e))?;
+    let file = File::open(image_path).map_err(|e| format!("Failed to open file: {e}"))?;
 
     let mut buf_reader = BufReader::new(file);
     let exif_reader = exif::Reader::new();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -52,7 +52,7 @@ pub fn run() {
             let cache_dir = app_data_dir.join("cache");
             if cache_dir.exists() {
                 if let Err(e) = std::fs::remove_dir_all(&cache_dir) {
-                    eprintln!("Failed to remove cache directory: {}", e);
+                    eprintln!("Failed to remove cache directory: {e}");
                 }
             }
             std::fs::create_dir_all(&cache_dir).expect("failed to create cache directory");

--- a/src-tauri/src/scanner.rs
+++ b/src-tauri/src/scanner.rs
@@ -55,11 +55,11 @@ impl ImageScanner {
     {
         // ディレクトリが存在するかチェック
         if !directory.exists() {
-            return Err(format!("Directory does not exist: {:?}", directory));
+            return Err(format!("Directory does not exist: {directory:?}"));
         }
 
         if !directory.is_dir() {
-            return Err(format!("Path is not a directory: {:?}", directory));
+            return Err(format!("Path is not a directory: {directory:?}"));
         }
 
         // WalkDirでファイルエントリを収集


### PR DESCRIPTION
Closes #57

## 背景
`ci.yml` は `cargo clippy -- -D warnings` をゲートにしているのに、clippy 0.1.88 で `uninlined_format_args`（`"...{}", e` → `"...{e}"`）が **54件**赤になり、ゲートが恒常的に機能していなかった。#56（golden e2e）の本筋と無関係な既存負債のため分離。

## 対応
`cargo clippy --fix --all-targets` で機械的にインライン化。**挙動不変**（フォーマット引数のインライン化のみ。clippy は式でなく束縛済み識別子だけをインライン化するので副作用なし）。10ファイル・53+/54−。

## 検証
- `cargo clippy --all-targets -- -D warnings` 緑
- `cargo clippy -- -D warnings`（CI と同コマンド）0件
- `cargo fmt --check` 緑
- `cargo test` 緑（lib 9 + golden e2e 3）
- 差分監査: stat 均衡（各行 `{}`+arg → `{ident}`）。format/println/eprintln 以外の変更なし。